### PR TITLE
feat: Add initial hagah request and history functionality

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -142,26 +142,27 @@ kotlin {
             }
         }
         commonTest.dependencies {
-            implementation(libs.kotlin.test)
-            implementation(libs.kotlin.coroutines.test)
-            implementation(libs.kotest)
-            implementation(libs.kotest.assertions.core)
-            implementation(libs.turbine)
-            implementation(libs.multiplatform.settings.test)
             @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
             implementation(libs.koin.test)
+            implementation(libs.kotest)
+            implementation(libs.kotest.assertions.core)
+            implementation(libs.kotlin.coroutines.test)
+            implementation(libs.kotlin.test)
+            implementation(libs.ktor.client.mock)
+            implementation(libs.multiplatform.settings.test)
+            implementation(libs.turbine)
         }
         androidMain {
             dependencies {
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.compose.ui.tooling.preview)
                 implementation(libs.androidx.foundation.layout.android)
+                implementation(libs.androidx.media3.exoplayer)
+                implementation(libs.androidx.media3.ui)
                 implementation(libs.koin.android)
                 implementation(libs.kstore.file)
                 implementation(libs.ktor.client.okhttp)
-                implementation(libs.androidx.media3.exoplayer)
-                implementation(libs.androidx.media3.ui)
             }
         }
         androidUnitTest.dependencies {
@@ -185,6 +186,7 @@ kotlin {
             implementation(libs.appdirs)
             implementation(libs.kstore.file)
             implementation(libs.composemediaplayer)
+            implementation(libs.slf4j.nop)
         }
         val desktopTest by getting
         desktopTest.dependencies {
@@ -265,7 +267,7 @@ compose {
         packageOfResClass = Config.packageOfResClass
         publicResClass = true
     }
-    android { }
+    android {}
     web { }
     desktop {
         application {
@@ -355,6 +357,20 @@ aboutLibraries {
 // Disable wasm tests for now
 tasks.named("wasmJsBrowserTest") {
     enabled = false
+}
+
+tasks.register<Copy>("copyiOSTestResources") {
+    from("src/commonTest/resources")
+    into("build/bin/iosX64/debugTest/resources")
+}
+
+listOf("iosX64Test", "iosSimulatorArm64Test").forEach { name ->
+    tasks.named(name).configure {
+        copy {
+            from("src/commonTest/resources")
+            into("build/bin/${name.removeSuffix("Test")}/debugTest/resources")
+        }
+    }
 }
 
 kover {

--- a/composeApp/src/androidUnitTest/kotlin/com/fergdev/hagah/ResourceLoader.android.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/fergdev/hagah/ResourceLoader.android.kt
@@ -1,0 +1,5 @@
+package com.fergdev.hagah
+
+import java.io.File
+
+actual fun loadTestResource(resourceName: String) = File("$RESOURCE_PATH/$resourceName").readText()

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/ArrowUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/ArrowUtil.kt
@@ -1,0 +1,9 @@
+package com.fergdev.hagah
+
+import arrow.core.Either
+
+inline fun <L, R, L2> Either<L, R>.flatMapLeft(transform: (L) -> Either<L2, R>): Either<L2, R> =
+    when (this) {
+        is Either.Left -> transform(value)
+        is Either.Right -> this
+    }

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/FViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/FViewModel.kt
@@ -1,0 +1,28 @@
+package com.fergdev.hagah
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+internal abstract class FViewModel<State, Action>(
+    initialState: State,
+    internal val dispatcher: CoroutineDispatcher
+) : ViewModel() {
+    inline fun launch(crossinline block: suspend CoroutineScope.() -> Unit) =
+        viewModelScope.launch(dispatcher) { block() }
+
+    private val _state = MutableStateFlow(initialState)
+    internal fun updateState(block: State.() -> State) = _state.update(block)
+    val state: StateFlow<State> = _state
+
+    private val _actions = MutableSharedFlow<Action>()
+    internal fun emitAction(action: Action) = launch { _actions.emit(action) }
+    val actions: Flow<Action> = _actions
+}

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/data/api/DailyDevotionalDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/data/api/DailyDevotionalDto.kt
@@ -8,13 +8,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DailyDevotionalWrapper(
+internal data class DailyDevotionalWrapper(
     @SerialName("dailyDevotional")
     val dailyDevotionalDto: DailyDevotionalDto
 )
 
 @Serializable
-data class DailyDevotionalDto(
+internal data class DailyDevotionalDto(
     @SerialName("verse")
     val verseDto: VerseDto,
     @SerialName("reflection")
@@ -26,23 +26,23 @@ data class DailyDevotionalDto(
 )
 
 @Serializable
-data class VerseDto(
+internal data class VerseDto(
     @SerialName("reference")
     val reference: String,
     @SerialName("text")
     val text: String
 )
 
-fun DailyDevotionalDto.toDomain(index: Long = 0L) = DailyHagah(
+internal fun DailyDevotionalDto.toDomain(index: Long = 0L) = DailyHagah(
     id = index,
     date = Clock.System.nowDate(),
     verse = verseDto.toDomain(),
     reflection = reflection,
     callToAction = callToAction,
-    prayer = prayer
+    prayer = prayer,
 )
 
-fun VerseDto.toDomain() = Verse(
+internal fun VerseDto.toDomain() = Verse(
     reference = reference,
     text = text
 )

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/data/api/HttpClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/data/api/HttpClient.kt
@@ -11,20 +11,16 @@ import io.ktor.http.ContentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private class KtorLogger : Logger {
-    override fun log(message: String) {
-        Napier.v(message = message, tag = "Ktor")
-    }
-}
-
 private const val HTTP_TIMEOUT = 60_000L
-private val json = Json {
-    ignoreUnknownKeys = true
-    encodeDefaults = true
-}
 internal val httpClient: HttpClient = HttpClient {
     install(ContentNegotiation) {
-        json(json = json, contentType = ContentType.Any)
+        json(
+            json = Json {
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            },
+            contentType = ContentType.Any
+        )
     }
     install(HttpTimeout) {
         requestTimeoutMillis = HTTP_TIMEOUT
@@ -32,6 +28,10 @@ internal val httpClient: HttpClient = HttpClient {
     }
     install(Logging) {
         level = LogLevel.ALL
-        logger = KtorLogger()
+        logger = object : Logger {
+            override fun log(message: String) {
+                Napier.v(message = message, tag = "Ktor")
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/data/storage/DailyDevotionalStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/data/storage/DailyDevotionalStorage.kt
@@ -1,29 +1,45 @@
 package com.fergdev.hagah.data.storage
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import com.fergdev.fcommon.coroutines.mapIfNull
 import com.fergdev.hagah.data.DailyHagah
+import com.fergdev.hagah.data.storage.DailyDevotionalStorage.Error.NotFound
 import io.github.aakira.napier.Napier
 import io.github.xxfast.kstore.KStore
 import io.github.xxfast.kstore.extensions.plus
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 
-interface DailyDevotionalStorage {
+internal interface DailyDevotionalStorage {
+    interface Error {
+        data object NotFound : Error
+    }
+
     suspend fun history(): Flow<List<DailyHagah>>
     suspend fun addDevotional(devotional: DailyHagah)
+    suspend fun getHagah(id: Long): Either<NotFound, DailyHagah>
 }
 
 const val HagahDb = "hagah.db"
 
-class DailyDevotionalStorageImpl(private val store: KStore<List<DailyHagah>>) :
+private const val LogTag = "Storage"
+
+internal class DailyDevotionalStorageImpl(private val store: KStore<List<DailyHagah>>) :
     DailyDevotionalStorage {
 
     override suspend fun history(): Flow<List<DailyHagah>> =
-        store.updates.mapIfNull(emptyList()).onEach {
-            Napier.d(message = it.toString(), tag = "storage - history")
-        }
+        store.updates
+            .mapIfNull(emptyList())
+            .onEach { Napier.d(message = it.toString(), tag = LogTag) }
 
-    override suspend fun addDevotional(devotional: DailyHagah) {
-        store.plus(devotional)
-    }
+    override suspend fun addDevotional(devotional: DailyHagah) = store.plus(devotional)
+    override suspend fun getHagah(id: Long): Either<NotFound, DailyHagah> =
+        history()
+            .first()
+            .firstOrNull { it.id == id }
+            ?.right()
+            ?: NotFound.left()
 }

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/screens/history/HistoryScreen.kt
@@ -46,10 +46,9 @@ fun HistoryScreen(modifier: Modifier = Modifier) {
     val state = viewModel.state.collectAsState()
 
     Box(modifier = modifier, contentAlignment = Center) {
-        when (state.value) {
+        when (val it = state.value) {
             is HistoryState.Loaded -> LoadedHistory(
-                history = state.value as HistoryState.Loaded,
-                onViewHistory = viewModel::onViewHistoryItem
+                history = it, onViewHistory = viewModel::onViewHistoryItem
             )
 
             HistoryState.Loading -> PulsingText("Loading History")
@@ -66,12 +65,10 @@ private fun LoadedHistory(
 ) {
     log(tag = "HistoryScreen") { "Loaded history ${history.historyMonths.size}" }
     val pagerState = rememberPagerState(
-        initialPage = 0,
-        pageCount = { history.historyMonths.size }
+        initialPage = 0, pageCount = { history.historyMonths.size }
     )
     HorizontalPager(
-        modifier = Modifier.fillMaxSize(),
-        state = pagerState
+        modifier = Modifier.fillMaxSize(), state = pagerState
     ) { page ->
         Box(contentAlignment = Center) {
             HistoryMonthView(month = history.historyMonths[page], onViewHistory = onViewHistory)
@@ -83,12 +80,10 @@ private fun LoadedHistory(
 private fun HistoryMonthView(month: HistoryMonth, onViewHistory: (HasHistory) -> Unit) {
     Box(modifier = Modifier.padding(16.dp)) {
         Column(
-            modifier = Modifier.padding(16.dp),
-            horizontalAlignment = CenterHorizontally
+            modifier = Modifier.padding(16.dp), horizontalAlignment = CenterHorizontally
         ) {
             Text(
-                text = month.title,
-                style = MaterialTheme.typography.titleLarge
+                text = month.title, style = MaterialTheme.typography.titleLarge
             )
             Spacer(height = 24.dp)
             HistoryCalendarView(days = month.list, onViewItem = onViewHistory)
@@ -110,11 +105,9 @@ private fun HistoryDay.backGroundAlpha() = when (this) {
     is HasHistory -> {
         val infiniteTransition = rememberInfiniteTransition(label = "Pulsing Text Transition")
         val alpha by infiniteTransition.animateFloat(
-            initialValue = UnusedAlpha,
-            targetValue = UsedAlpha,
+            initialValue = UnusedAlpha, targetValue = UsedAlpha,
             animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis = 600),
-                repeatMode = RepeatMode.Reverse
+                animation = tween(durationMillis = 600), repeatMode = RepeatMode.Reverse
             ),
             label = "Pulsing Text Alpha"
         )
@@ -148,8 +141,7 @@ private fun HistoryCalendarView(
     ) {
         items(titles) {
             Box(
-                modifier = Modifier.padding(4.dp),
-                contentAlignment = Center
+                modifier = Modifier.padding(4.dp), contentAlignment = Center
             ) {
                 Text(
                     text = it,
@@ -159,16 +151,14 @@ private fun HistoryCalendarView(
         }
         items(days) { day ->
             Box(
-                modifier = Modifier.padding(4.dp)
-                    .background(day.backGroundColor())
+                modifier = Modifier.padding(4.dp).background(day.backGroundColor())
                     .conditional<HasHistory, _>(day) {
                         clickable { onViewItem(it) }
                     },
                 contentAlignment = Center
             ) {
                 Text(
-                    text = "${day.dayOfMonth}",
-                    color = day.textColor()
+                    text = "${day.dayOfMonth}", color = day.textColor()
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/fergdev/hagah/screens/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/fergdev/hagah/screens/settings/SettingsViewModel.kt
@@ -1,31 +1,28 @@
 package com.fergdev.hagah.screens.settings
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fergdev.hagah.AppSettingsManager
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import com.fergdev.hagah.FViewModel
+import com.fergdev.hagah.screens.settings.SettingsViewModel.State
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 internal class SettingsViewModel(
-    private val settings: AppSettingsManager
-) : ViewModel() {
+    private val settings: AppSettingsManager,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main
+) : FViewModel<State, Nothing>(initialState = State(), dispatcher = dispatcher) {
     data class State(val meditationDuration: Long = 0L)
-
-    private val _state = MutableStateFlow<State>(State())
-    val state: StateFlow<State> = _state
 
     init {
         viewModelScope.launch {
             settings.settings.collect {
-                _state.value = State(meditationDuration = it.meditationLength)
+                updateState { State(meditationDuration = it.meditationLength) }
             }
         }
     }
 
     fun setMeditationDuration(duration: Long) {
-        viewModelScope.launch {
-            settings.setMeditationDuration(duration)
-        }
+        launch { settings.setMeditationDuration(duration) }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/fergdev/hagah/ArrowUtil.kt
+++ b/composeApp/src/commonTest/kotlin/com/fergdev/hagah/ArrowUtil.kt
@@ -1,0 +1,15 @@
+package com.fergdev.hagah
+
+import arrow.core.Either
+import io.kotest.assertions.fail
+import io.kotest.matchers.shouldBe
+
+infix fun <L, R> Either<L, R>.shouldBeLeft(l: L) = this.fold(
+    ifLeft = { it shouldBe l },
+    ifRight = { fail("Expected left, but got right: $it") }
+)
+
+infix fun <L, R> Either<L, R>.shouldBeRight(r: R) = this.fold(
+    ifLeft = { fail("Expected right, but got left: $it") },
+    ifRight = { it shouldBe r }
+)

--- a/composeApp/src/commonTest/kotlin/com/fergdev/hagah/ResourceLoader.kt
+++ b/composeApp/src/commonTest/kotlin/com/fergdev/hagah/ResourceLoader.kt
@@ -1,0 +1,4 @@
+package com.fergdev.hagah
+const val RESOURCE_PATH = "./src/commonTest/resources"
+
+expect fun loadTestResource(resourceName: String): String

--- a/composeApp/src/commonTest/kotlin/com/fergdev/hagah/data/api/DailyDevotionalApiImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/fergdev/hagah/data/api/DailyDevotionalApiImplTest.kt
@@ -1,0 +1,120 @@
+package com.fergdev.hagah.data.api
+
+import com.fergdev.hagah.data.api.DailyDevotionalApi.Error.Server
+import com.fergdev.hagah.loadTestResource
+import com.fergdev.hagah.shouldBeLeft
+import com.fergdev.hagah.shouldBeRight
+import io.kotest.core.spec.style.FreeSpec
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.io.IOException
+import kotlinx.serialization.json.Json
+
+private val SuccessDto = DailyDevotionalDto(
+    verseDto = VerseDto(
+        reference = "John 13:34",
+        text = "A new command I give you: Love one another. As I have loved you, so you must love one another."
+    ),
+    reflection = "In today's verse, Jesus gives us one of the most profound commandments - to love one another just as He loved us. Love is such a powerful force, it can heal, transform, and bring about the most awe-inspiring changes. Yet in the world today, we often find it hard to genuinely love our neighbours. Let's use today as an opportunity to reflect on how we can grow in love and bring Jesus's commandment to life in our actions.",
+    callToAction = "Take a moment to consider the people around you. Could be your family, your friends, your colleagues or even strangers you pass on the street. Engage in a deliberate act of kindness today, it could be as simple as a smile, a kind word or a selfless act of service. By doing so, you are loving others as Christ loved you.",
+    prayer = "Lord Jesus, thank You for Your great love for us. Help us to understand and appreciate that love so that we may extend it to those around us. Grant us a kind and compassionate heart, that we may look past differences and embrace everyone with open arms. Teach us to love as You have loved us. Amen."
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DailyDevotionalApiImplTest : FreeSpec({
+    val initApi: (resource: String) -> DailyDevotionalApi = { resource ->
+        val data = loadTestResource(resource)
+        val mockEngine = MockEngine {
+            respond(
+                content = data,
+                status = HttpStatusCode.OK,
+                headers = headersOf(
+                    HttpHeaders.ContentType,
+                    ContentType.Application.Json.toString()
+                )
+            )
+        }
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        DailyDevotionalApiImpl(client)
+    }
+
+    "requestHagah() should return DailyDevotionalDto on success" {
+        initApi("chatgpt_success.json").requestHagah() shouldBeRight SuccessDto
+    }
+
+    "requestHagah() should return DailyDevotionalDto on success with wrapper" {
+        initApi("chatgpt_success_wrapper.json").requestHagah() shouldBeRight SuccessDto
+    }
+
+    "requestHagah() should return Network error on IOException" {
+        DailyDevotionalApiImpl(
+            HttpClient(
+                MockEngine {
+                    throw IOException("Simulated network error")
+                }
+            )
+        ).requestHagah()
+            .shouldBeLeft(Server)
+    }
+
+    "requestHagah() should return Network error on Exception" {
+        DailyDevotionalApiImpl(
+            HttpClient(
+                MockEngine {
+                    throw Exception("Random error")
+                }
+            )
+        ).requestHagah() shouldBeLeft Server
+    }
+
+    "requestHagah() should return Server error on non-200 response" {
+        val mockEngine = MockEngine {
+            respond(
+                content = "{}",
+                status = HttpStatusCode.InternalServerError,
+                headers = headersOf(
+                    HttpHeaders.ContentType,
+                    ContentType.Application.Json.toString()
+                )
+            )
+        }
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        DailyDevotionalApiImpl(client).requestHagah() shouldBeLeft Server
+    }
+
+    "requestHagah() should return Server error on invalid JSON response" {
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    content = """ { "invalid": "json" } """.trimIndent(),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        HttpHeaders.ContentType,
+                        ContentType.Application.Json.toString()
+                    )
+                )
+            }
+        ) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        DailyDevotionalApiImpl(client).requestHagah() shouldBeLeft Server
+    }
+})

--- a/composeApp/src/commonTest/resources/chatgpt_success.json
+++ b/composeApp/src/commonTest/resources/chatgpt_success.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-BM4ItuMPhIGlBFnN11ySRqHIt7Bes",
+  "object": "chat.completion",
+  "created": 1744599459,
+  "model": "gpt-4-0613",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\n  \"verse\": {\n    \"reference\": \"John 13:34\",\n    \"text\": \"A new command I give you: Love one another. As I have loved you, so you must love one another.\"\n  },\n  \"reflection\": \"In today's verse, Jesus gives us one of the most profound commandments - to love one another just as He loved us. Love is such a powerful force, it can heal, transform, and bring about the most awe-inspiring changes. Yet in the world today, we often find it hard to genuinely love our neighbours. Let's use today as an opportunity to reflect on how we can grow in love and bring Jesus's commandment to life in our actions.\",\n  \"callToAction\": \"Take a moment to consider the people around you. Could be your family, your friends, your colleagues or even strangers you pass on the street. Engage in a deliberate act of kindness today, it could be as simple as a smile, a kind word or a selfless act of service. By doing so, you are loving others as Christ loved you.\",\n  \"prayer\": \"Lord Jesus, thank You for Your great love for us. Help us to understand and appreciate that love so that we may extend it to those around us. Grant us a kind and compassionate heart, that we may look past differences and embrace everyone with open arms. Teach us to love as You have loved us. Amen.\"\n}",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 53,
+    "completion_tokens": 298,
+    "total_tokens": 351,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/composeApp/src/commonTest/resources/chatgpt_success_wrapper.json
+++ b/composeApp/src/commonTest/resources/chatgpt_success_wrapper.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-BM4ItuMPhIGlBFnN11ySRqHIt7Bes",
+  "object": "chat.completion",
+  "created": 1744599459,
+  "model": "gpt-4-0613",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\n \"dailyDevotional\": { \"verse\": {\n    \"reference\": \"John 13:34\",\n    \"text\": \"A new command I give you: Love one another. As I have loved you, so you must love one another.\"\n  },\n  \"reflection\": \"In today's verse, Jesus gives us one of the most profound commandments - to love one another just as He loved us. Love is such a powerful force, it can heal, transform, and bring about the most awe-inspiring changes. Yet in the world today, we often find it hard to genuinely love our neighbours. Let's use today as an opportunity to reflect on how we can grow in love and bring Jesus's commandment to life in our actions.\",\n  \"callToAction\": \"Take a moment to consider the people around you. Could be your family, your friends, your colleagues or even strangers you pass on the street. Engage in a deliberate act of kindness today, it could be as simple as a smile, a kind word or a selfless act of service. By doing so, you are loving others as Christ loved you.\",\n  \"prayer\": \"Lord Jesus, thank You for Your great love for us. Help us to understand and appreciate that love so that we may extend it to those around us. Grant us a kind and compassionate heart, that we may look past differences and embrace everyone with open arms. Teach us to love as You have loved us. Amen.\"\n}}",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 53,
+    "completion_tokens": 298,
+    "total_tokens": 351,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/composeApp/src/desktopTest/kotlin/com/fergdev/hagah/ResourceLoader.desktop.kt
+++ b/composeApp/src/desktopTest/kotlin/com/fergdev/hagah/ResourceLoader.desktop.kt
@@ -1,0 +1,5 @@
+package com.fergdev.hagah
+
+import java.io.File
+
+actual fun loadTestResource(resourceName: String) = File("${RESOURCE_PATH}/$resourceName").readText()

--- a/composeApp/src/iosTest/kotlin/com/fergdev/hagah/ResourceLoader.ios.kt
+++ b/composeApp/src/iosTest/kotlin/com/fergdev/hagah/ResourceLoader.ios.kt
@@ -1,0 +1,39 @@
+package com.fergdev.hagah
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.Foundation.NSBundle
+import platform.Foundation.NSError
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.stringWithContentsOfFile
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+actual fun loadTestResource(resourceName: String): String {
+    val pathParts = resourceName.split("[.|/]".toRegex())
+    println(pathParts)
+//    val path = NSBundle.mainBundle.pathForResource("/resources/${pathParts[0]}", pathParts[1])
+    val path = "${NSBundle.mainBundle.bundlePath}/resources/$resourceName"
+    println("Bundle path $path")
+    requireNotNull(path) {
+        "Error loading resource $path"
+    }
+//    val file: CPointer<FILE>? = fopen(path, "r")
+//    val size = ftell(file)
+//    rewind(file)
+//    return memScoped {
+//        val tmp = allocArray<ByteVar>(size)
+//        fread(tmp, sizeOf<ByteVar>().convert(), size.convert(), file)
+//        tmp.toKString()
+//    }
+    return memScoped {
+        val error = alloc<ObjCObjectVar<NSError?>>()
+        NSString.stringWithContentsOfFile(path, NSUTF8StringEncoding, error.ptr)
+            ?: error("$path: Read failed: ${error.value}")
+    }
+}

--- a/composeApp/src/wasmJsTest/kotlin/com/fergdev/hagah/ResourceLoader.wasmJs.kt
+++ b/composeApp/src/wasmJsTest/kotlin/com/fergdev/hagah/ResourceLoader.wasmJs.kt
@@ -1,0 +1,6 @@
+package com.fergdev.hagah
+
+actual fun loadTestResource(resourceName: String): String {
+    require(false) { "Soon" }
+    return ""
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -258,6 +258,7 @@ exceptions:
     allowedExceptionNameRegex: '_|(ignored|expected).*'
   TooGenericExceptionThrown:
     active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**',  '**.kts', '**/kotestTest/**' ]
     exceptionNames:
       - 'Error'
       - 'Exception'
@@ -306,6 +307,7 @@ formatting:
     active: false # duplicated by formatting
     maxLineLength: 120
     ignoreBackTickedIdentifier: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**',  '**.kts', '**/kotestTest/**', '**/androidHostTest/**', '**/androidDeviceTest/**' ]
   ModifierOrdering:
     active: true
     autoCorrect: true
@@ -701,6 +703,7 @@ style:
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**',  '**.kts', '**/kotestTest/**', '**/androidHostTest/**', '**/androidDeviceTest/**' ]
   MayBeConst:
     active: true
   ModifierOrder:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ multiplatformSettings = "1.3.0"
 napier = "2.7.1"
 navigationCompose = "2.8.0-alpha08"
 runner = "1.6.2"
+slf4jNop = "2.0.17"
 turbine = "1.2.0"
 versionCatalogUpdatePlugin = "1.0.0"
 
@@ -91,6 +92,8 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatformSettings" }
@@ -99,6 +102,7 @@ multiplatform-settings-observable = { module = "com.russhwolf:multiplatform-sett
 multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatformSettings" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4jNop" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]


### PR DESCRIPTION
This commit introduces the foundation for requesting and storing daily devotions, along with basic history management.

-   Adds `ArrowUtil` for handling `Either` in common code.
-   Adds test helper functions for `Either`.
-   Adds `FViewModel` for common `ViewModel` features.
-   Adds `loadTestResource` to load test data for different platforms.
-   Adds `DailyDevotionalApiImplTest` for testing the API.
-   Adds initial JSON for test response from chatgpt.
-   Adds `DailyDevotionalApi` to request the daily devotional.
-   Adds `DataRepository` for managing the daily devotional data.
-   Adds `DailyDevotionalStorage` to store daily devotionals.
-   Adds `HistoryViewModel` to manage the history list.
-   Adds `HistoryScreen` for viewing the history list.
-   Adds `MainViewModel` for fetching the daily devotional.
-   Adds `MainScreen` to display the daily devotional.
-   Adds `VideoRepository` for managing available videos.
-   Adds `SettingsViewModel` to adjust meditation time.
-   Refactors `DailyDevotionalDto`, `VerseDto` to internal.
-   Refactors `httpClient` to not log response body.
-   Fixes for detekt.
-   Adds logging to Ktor client.
-   Adds test dependencies.
-   Adds copy resources to ios tests.